### PR TITLE
Remove unnecessary require

### DIFF
--- a/lib/missinglink.rb
+++ b/lib/missinglink.rb
@@ -1,4 +1,3 @@
-require 'pry'
 require "missinglink/engine"
 require "missinglink/connection"
 


### PR DESCRIPTION
When i run: 
bundle exec rake missinglink:install:migrations

And i have an error: 

rake aborted!
LoadError: cannot load such file -- pry
/home/gabrielsouza/.rvm/gems/ruby-2.0.0-p353/gems/missinglink-0.2.6/lib/missinglink.rb:1:in `require'
/home/gabrielsouza/.rvm/gems/ruby-2.0.0-p353/gems/missinglink-0.2.6/lib/missinglink.rb:1:in`<top ...

I open gem with bundle open and remove unnecessary require, and gem works...

bundle exec rake missinglink:install:migrations
Copied migration 20150915214751_add_missinglink_survey_schema.missinglink.rb from missinglink

:)
