### PR TITLE
Change type in migration

### DIFF
--- a/db/migrate/20140308005724_add_missinglink_survey_schema.rb
+++ b/db/migrate/20140308005724_add_missinglink_survey_schema.rb
@@ -17,7 +17,7 @@ class AddMissinglinkSurveySchema < ActiveRecord::Migration
     add_index :surveys, :sm_survey_id
 
     create_table :survey_pages do |t|
-      t.integer   :survey_id
+      t.column   :survey_id, :bigint
       t.column    :sm_page_id, :bigint
       t.text      :heading
       t.text      :sub_heading
@@ -68,7 +68,7 @@ class AddMissinglinkSurveySchema < ActiveRecord::Migration
     add_index :survey_answers, :survey_question_id
 
     create_table :survey_respondent_details do |t|
-      t.integer   :survey_id
+      t.column   :survey_id, :bigint
       t.column    :sm_respondent_id, :bigint
       t.timestamp :date_start
       t.timestamp :date_modified

--- a/lib/missinglink.rb
+++ b/lib/missinglink.rb
@@ -1,4 +1,3 @@
-require 'pry'
 require "missinglink/engine"
 require "missinglink/connection"
 


### PR DESCRIPTION
Change type of column for avoid this error:

RangeError: 9395961186 is out of range for ActiveRecord::Type::Integer with limit 4

In execution of this command

Missinglink.poll_surveys
